### PR TITLE
fix: resolving prompt environment order by createdAt desc

### DIFF
--- a/apps/server/src/app/prompts/prompts.resolver.ts
+++ b/apps/server/src/app/prompts/prompts.resolver.ts
@@ -353,6 +353,7 @@ export class PromptsResolver {
     try {
       deployedPrompt = await this.prisma.promptEnvironment.findFirst({
         where: { promptId: prompt.id, environmentId: environment.id },
+        orderBy: { createdAt: "desc" },
       });
     } catch (error) {
       this.logger.error({ error }, "Error getting deployed prompt environment");


### PR DESCRIPTION
Fixes #53 

When resolving `deployedVersion` of a `Prompt`, we add `orderBy: { createdAt: "desc" }` to ensure we get the latest deployed version.