### PR TITLE
feat: interpolate variables with single curly brace (BREAKING)

### DIFF
--- a/apps/console/src/app/lib/hooks/usePromptEdit.ts
+++ b/apps/console/src/app/lib/hooks/usePromptEdit.ts
@@ -1,4 +1,3 @@
-import { OpenAIChatSettings } from "@pezzo/common";
 import { Form } from "antd";
 import { useEffect, useState } from "react";
 import { useCurrentPrompt } from "../providers/CurrentPromptContext";
@@ -6,11 +5,11 @@ import { getIntegration } from "@pezzo/integrations";
 
 export type PromptEditFormInputs = {
   content: string;
-  settings: OpenAIChatSettings;
+  settings: any;
 };
 
 function findVariables(text: string): Record<string, null> {
-  const regex = /\{\{([\w\s]+)\}\}/g;
+  const regex = /\{([\w\s]+)\}/g;
   const matches = text.match(regex);
   const interpolatableValues = matches
     ? matches.map((match) => match.replace(/[{}]/g, ""))

--- a/apps/console/src/app/lib/providers/PromptTesterContext.tsx
+++ b/apps/console/src/app/lib/providers/PromptTesterContext.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext, useState } from "react";
-import { OpenAIChatSettings } from "@pezzo/common";
 import { TEST_PROMPT } from "../../graphql/mutations/prompts";
 import { gqlClient } from "../graphql";
 import { GetPromptExecutionQuery, PromptExecution } from "@pezzo/graphql";
@@ -9,7 +8,7 @@ import { useCurrentProject } from "../hooks/useCurrentProject";
 
 export interface PromptTestInput {
   content: string;
-  settings: OpenAIChatSettings;
+  settings: any;
   variables: Record<string, string>;
 }
 

--- a/apps/server/src/app/prompts/inputs/create-prompt-version.input.ts
+++ b/apps/server/src/app/prompts/inputs/create-prompt-version.input.ts
@@ -1,5 +1,4 @@
 import { Field, InputType } from "@nestjs/graphql";
-import { OpenAIChatSettings } from "@pezzo/common";
 import GraphQLJSON from "graphql-type-json";
 
 @InputType()
@@ -14,5 +13,5 @@ export class CreatePromptVersionInput {
   promptId: string;
 
   @Field(() => GraphQLJSON, { nullable: false })
-  settings: OpenAIChatSettings;
+  settings: any;
 }

--- a/apps/server/src/app/prompts/prompt-tester.service.ts
+++ b/apps/server/src/app/prompts/prompt-tester.service.ts
@@ -35,6 +35,7 @@ export class PromptTesterService {
     projectId: string
   ): Promise<TestPromptResult> {
     const { integrationId, content, variables } = input;
+    console.log("variables", variables);
     const interpolatedContent = interpolateVariables(content, variables);
     const executor = await this.executorFactory(integrationId, projectId);
     const settings = input.settings;

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -3,21 +3,3 @@ import * as versionJson from "./version.json";
 export const version = versionJson.version;
 
 export * from "./utils";
-
-export interface OpenAIChatSettings {
-  model: "gpt-3.5-turbo" | "gpt-4";
-  temperature: number;
-  max_tokens: number;
-  top_p: number;
-  frequency_penalty: number;
-  presence_penalty: number;
-}
-
-export const defaultOpenAIChatSettings: OpenAIChatSettings = {
-  model: "gpt-3.5-turbo",
-  temperature: 0.7,
-  max_tokens: 256,
-  top_p: 1,
-  frequency_penalty: 0,
-  presence_penalty: 0,
-};

--- a/libs/common/src/utils/interpolate-variables.ts
+++ b/libs/common/src/utils/interpolate-variables.ts
@@ -2,7 +2,7 @@ export function interpolateVariables(
   text: string,
   variables: Record<string, boolean | number | string>
 ): string {
-  return text.replace(/{{\s*(\w+)\s*}}/g, (match, key) =>
+  return text.replace(/{\s*(\w+)\s*}/g, (match, key) =>
     // eslint-disable-next-line no-prototype-builtins
     variables.hasOwnProperty(key) ? String(variables[key]) : match
   );

--- a/libs/integrations/src/lib/utils/interpolate-variables.ts
+++ b/libs/integrations/src/lib/utils/interpolate-variables.ts
@@ -2,7 +2,7 @@ export function interpolateVariables(
   text: string,
   variables: Record<string, boolean | number | string>
 ): string {
-  return text.replace(/{{\s*(\w+)\s*}}/g, (match, key) =>
+  return text.replace(/{\s*(\w+)\s*}/g, (match, key) =>
     // eslint-disable-next-line no-prototype-builtins
     variables.hasOwnProperty(key) ? String(variables[key]) : match
   );


### PR DESCRIPTION
Interpolate variables with a single curly brace instead of two. E.g. `{variable}` instead of `{{variable}}` for better compatibility with LangChain.