### PR TITLE
feat: add filters and sort

### DIFF
--- a/apps/console/src/app/graphql/hooks/filters.ts
+++ b/apps/console/src/app/graphql/hooks/filters.ts
@@ -1,0 +1,57 @@
+import { useSearchParams } from "react-router-dom";
+import { useEffect, useMemo } from "react";
+import {
+  FilterOperator,
+  FilterType,
+  SortDirection,
+} from "../../../@generated/graphql/graphql";
+
+const extractSortAndFiltersFromSearchParams = (
+  searchParams: URLSearchParams
+) => {
+  const filterParams: (string | null)[] | null = searchParams.getAll("f");
+  const filters = filterParams?.map((filterParam) => {
+    const [field, operator, value, secondValue] = (filterParam ?? ":").split(
+      ":"
+    );
+    return {
+      type: FilterType.Filter,
+      field,
+      operator: operator as FilterOperator,
+      value,
+      secondValue,
+    };
+  });
+
+  const sortParam = searchParams.get("sort");
+  // eslint-disable-next-line no-unsafe-optional-chaining
+  const [sortField, sortDirection] = sortParam?.split(":") ?? [];
+
+  return {
+    filters,
+    sort: sortField &&
+      sortDirection && {
+        type: FilterType.Sort,
+        field: sortField,
+        direction: (sortDirection as SortDirection) ?? SortDirection.Desc,
+      },
+  };
+};
+
+export const useFiltersAndSortParams = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const { filters, sort } = useMemo(
+    () => extractSortAndFiltersFromSearchParams(searchParams),
+    [searchParams]
+  );
+
+  useEffect(() => {
+    if (!sort) setSearchParams({ sort: "request.timestamp:desc" });
+  }, [setSearchParams, sort]);
+
+  return {
+    filters,
+    sort,
+  };
+};

--- a/apps/console/src/app/graphql/hooks/filters.ts
+++ b/apps/console/src/app/graphql/hooks/filters.ts
@@ -1,10 +1,6 @@
 import { useSearchParams } from "react-router-dom";
 import { useEffect, useMemo } from "react";
-import {
-  FilterOperator,
-  FilterType,
-  SortDirection,
-} from "../../../@generated/graphql/graphql";
+import { FilterOperator, SortOrder } from "../../../@generated/graphql/graphql";
 
 const extractSortAndFiltersFromSearchParams = (
   searchParams: URLSearchParams
@@ -15,7 +11,6 @@ const extractSortAndFiltersFromSearchParams = (
       ":"
     );
     return {
-      type: FilterType.Filter,
       field,
       operator: operator as FilterOperator,
       value,
@@ -25,15 +20,14 @@ const extractSortAndFiltersFromSearchParams = (
 
   const sortParam = searchParams.get("sort");
   // eslint-disable-next-line no-unsafe-optional-chaining
-  const [sortField, sortDirection] = sortParam?.split(":") ?? [];
+  const [sortField, sortOrder] = sortParam?.split(":") ?? [];
 
   return {
     filters,
     sort: sortField &&
-      sortDirection && {
-        type: FilterType.Sort,
+      sortOrder && {
         field: sortField,
-        direction: (sortDirection as SortDirection) ?? SortDirection.Desc,
+        order: (sortOrder as SortOrder) ?? SortOrder.Desc,
       },
   };
 };

--- a/apps/console/src/app/graphql/hooks/queries.ts
+++ b/apps/console/src/app/graphql/hooks/queries.ts
@@ -12,6 +12,7 @@ import { GET_ALL_REQUESTS } from "../definitions/queries/requests";
 import { Pagination, RequestReport } from "../../../@generated/graphql/graphql";
 import { ReportRequestResponse } from "../types";
 import { ProviderType } from "@pezzo/types";
+import { useFiltersAndSortParams } from "./filters";
 
 export const useProviderApiKeys = () => {
   const { organization } = useCurrentOrganization();
@@ -67,18 +68,30 @@ const buildTypedRequestReportObject = (requestReport: RequestReport) => {
   }
 }
 
-export const useGetRequestReports = ({ size = 10, page = 1 }: { size: number; page: number }) => {
+export const useGetRequestReports = ({
+  size = 10,
+  page = 1,
+}: {
+  size: number;
+  page: number;
+}) => {
   const { project } = useCurrentProject();
+  const { filters, sort } = useFiltersAndSortParams();
 
   const response = useQuery({
     queryKey: ["requestReports", project?.id, page, size],
     queryFn: () =>
       gqlClient.request<{ paginatedRequests: { pagination: Pagination; data: RequestReport[] } }>(GET_ALL_REQUESTS, {
-        data: { projectId: project?.id, size, page },
+        data: {
+          projectId: project?.id,
+          filters,
+          sort,
+          size,
+          page,
+        },
       }),
     enabled: !!project,
   });
-
   const typedData = response.data?.paginatedRequests.data?.map(buildTypedRequestReportObject) ?? [];
 
   return {
@@ -91,6 +104,4 @@ export const useGetRequestReports = ({ size = 10, page = 1 }: { size: number; pa
       },
     },
   };
-
-
-}
+};

--- a/apps/server/src/app/common/filters/filter.input.ts
+++ b/apps/server/src/app/common/filters/filter.input.ts
@@ -1,5 +1,5 @@
 import { Field, InputType, registerEnumType } from "@nestjs/graphql";
-import { FilterType, RequestReportFilterFields } from "./shared";
+import { RequestReportFilterFields } from "./shared";
 
 export enum FilterOperator {
   eq = "eq",
@@ -18,9 +18,6 @@ registerEnumType(FilterOperator, {
 
 @InputType()
 export class FilterInput {
-  @Field(() => FilterType, { nullable: false })
-  type: FilterType.Filter;
-
   @Field(() => String, { nullable: false })
   field: RequestReportFilterFields;
 

--- a/apps/server/src/app/common/filters/filter.input.ts
+++ b/apps/server/src/app/common/filters/filter.input.ts
@@ -1,0 +1,35 @@
+import { Field, InputType, registerEnumType } from "@nestjs/graphql";
+import { FilterType, RequestReportFilterFields } from "./shared";
+
+export enum FilterOperator {
+  eq = "eq",
+  neq = "neq",
+  in = "in",
+  nin = "nin",
+  contains = "contains",
+  gt = "gt",
+  gte = "gte",
+  lt = "lt",
+  lte = "lte",
+}
+registerEnumType(FilterOperator, {
+  name: "FilterOperator",
+});
+
+@InputType()
+export class FilterInput {
+  @Field(() => FilterType, { nullable: false })
+  type: FilterType.Filter;
+
+  @Field(() => String, { nullable: false })
+  field: RequestReportFilterFields;
+
+  @Field(() => FilterOperator, { nullable: false })
+  operator: FilterOperator;
+
+  @Field(() => String, { nullable: false })
+  value: string | string[];
+
+  @Field(() => String, { nullable: true })
+  secondValue?: string | string[];
+}

--- a/apps/server/src/app/common/filters/shared.ts
+++ b/apps/server/src/app/common/filters/shared.ts
@@ -1,13 +1,4 @@
-import { registerEnumType } from "@nestjs/graphql";
 import { RequestReport } from "../../reporting/object-types/request-report.model";
-
-export enum FilterType {
-  Filter = "filter",
-  Sort = "sort",
-}
-registerEnumType(FilterType, {
-  name: "FilterType",
-});
 
 export type FilterFields<TMainKey extends keyof RequestReport> =
   RequestReport[TMainKey] extends Record<never, never>

--- a/apps/server/src/app/common/filters/shared.ts
+++ b/apps/server/src/app/common/filters/shared.ts
@@ -1,0 +1,19 @@
+import { registerEnumType } from "@nestjs/graphql";
+import { RequestReport } from "../../reporting/object-types/request-report.model";
+
+export enum FilterType {
+  Filter = "filter",
+  Sort = "sort",
+}
+registerEnumType(FilterType, {
+  name: "FilterType",
+});
+
+export type FilterFields<TMainKey extends keyof RequestReport> =
+  RequestReport[TMainKey] extends Record<never, never>
+    ? keyof RequestReport[TMainKey] extends string
+      ? `${TMainKey}.${keyof RequestReport[TMainKey]}`
+      : `${TMainKey}`
+    : `${TMainKey}`;
+
+export type RequestReportFilterFields = FilterFields<keyof RequestReport>;

--- a/apps/server/src/app/common/filters/sort.input.ts
+++ b/apps/server/src/app/common/filters/sort.input.ts
@@ -1,23 +1,20 @@
 import { Field, InputType, registerEnumType } from "@nestjs/graphql";
-import { FilterType, RequestReportFilterFields } from "./shared";
+import { RequestReportFilterFields } from "./shared";
 
 // Enum keys are read by GQL, which means they need to be lowercase
-export enum SortDirection {
+export enum SortOrder {
   asc = "asc",
   desc = "desc",
 }
-registerEnumType(SortDirection, {
-  name: "SortDirection",
+registerEnumType(SortOrder, {
+  name: "SortOrder",
 });
 
 @InputType()
 export class SortInput {
-  @Field(() => FilterType, { nullable: false })
-  type: FilterType.Sort;
-
   @Field(() => String, { nullable: false })
   field: RequestReportFilterFields;
 
-  @Field(() => SortDirection, { nullable: false })
-  direction: SortDirection;
+  @Field(() => SortOrder, { nullable: false })
+  order: SortOrder;
 }

--- a/apps/server/src/app/common/filters/sort.input.ts
+++ b/apps/server/src/app/common/filters/sort.input.ts
@@ -1,0 +1,23 @@
+import { Field, InputType, registerEnumType } from "@nestjs/graphql";
+import { FilterType, RequestReportFilterFields } from "./shared";
+
+// Enum keys are read by GQL, which means they need to be lowercase
+export enum SortDirection {
+  asc = "asc",
+  desc = "desc",
+}
+registerEnumType(SortDirection, {
+  name: "SortDirection",
+});
+
+@InputType()
+export class SortInput {
+  @Field(() => FilterType, { nullable: false })
+  type: FilterType.Sort;
+
+  @Field(() => String, { nullable: false })
+  field: RequestReportFilterFields;
+
+  @Field(() => SortDirection, { nullable: false })
+  direction: SortDirection;
+}

--- a/apps/server/src/app/reporting/inputs/get-requests.input.ts
+++ b/apps/server/src/app/reporting/inputs/get-requests.input.ts
@@ -1,4 +1,6 @@
 import { Field, InputType } from "@nestjs/graphql";
+import { FilterInput } from "../../common/filters/filter.input";
+import { SortInput } from "../../common/filters/sort.input";
 
 @InputType()
 export class GetRequestsInput {
@@ -10,4 +12,10 @@ export class GetRequestsInput {
 
   @Field(() => Number, { nullable: false, defaultValue: 10 })
   size: number;
+
+  @Field(() => [FilterInput], { nullable: true })
+  filters?: FilterInput[];
+
+  @Field(() => SortInput, { nullable: true })
+  sort?: SortInput;
 }

--- a/apps/server/src/app/reporting/reporting.service.ts
+++ b/apps/server/src/app/reporting/reporting.service.ts
@@ -6,10 +6,13 @@ import { randomUUID } from "crypto";
 import { buildRequestReport } from "./utils/build-request-report";
 import { RequestReport } from "./object-types/request-report.model";
 import { MAX_PAGE_SIZE } from "../../lib/pagination";
+import { FilterInput } from "../common/filters/filter.input";
+import { SortInput } from "../common/filters/sort.input";
+import { mapFiltersToDql } from "./utils/dql-utils";
 
 @Injectable()
 export class ReportingService {
-  constructor(private openSearchService: OpenSearchService) { }
+  constructor(private openSearchService: OpenSearchService) {}
 
   async saveReport(
     dto: ReportRequestDto,
@@ -23,7 +26,7 @@ export class ReportingService {
 
     const { provider, type, properties, metadata, request, response } = report;
 
-    const result = await this.openSearchService.client.index({
+    return this.openSearchService.client.index({
       index: OpenSearchIndex.Requests,
       body: {
         ownership,
@@ -37,31 +40,36 @@ export class ReportingService {
         response,
       },
     });
-
-    return result;
   }
 
-  async getReports({ projectId, page, size: pageSize }: { projectId: string, page: number, size: number }) {
-
+  async getReports({
+    projectId,
+    organizationId,
+    page,
+    size: pageSize,
+    filters,
+    sort,
+  }: {
+    projectId: string;
+    organizationId: string;
+    page: number;
+    size: number;
+    filters?: FilterInput[];
+    sort?: SortInput;
+  }) {
     const size = pageSize > MAX_PAGE_SIZE ? MAX_PAGE_SIZE : pageSize;
     const from = (page - 1) * size;
 
-    return await this.openSearchService.client.search<{
+    const dql = mapFiltersToDql({ projectId, organizationId, filters, sort });
+
+    return this.openSearchService.client.search<{
       hits: {
-        hits: Array<{ _source: RequestReport; }>
+        hits: Array<{ _source: RequestReport }>;
         total: { value: number };
       };
     }>({
       index: OpenSearchIndex.Requests,
-      body: {
-        query: {
-          match: {
-            "ownership.projectId": projectId,
-          },
-        },
-
-      },
-      sort: ["request.timestamp:desc"],
+      body: dql,
       size,
       from,
       track_total_hits: true,

--- a/apps/server/src/app/reporting/utils/dql-utils.ts
+++ b/apps/server/src/app/reporting/utils/dql-utils.ts
@@ -1,0 +1,124 @@
+import { FilterInput, FilterOperator } from "../../common/filters/filter.input";
+import { SortInput } from "../../common/filters/sort.input";
+import bodybuilder from "bodybuilder";
+
+const exampleReport = {
+  ownership: {
+    organizationId: "cljdau1v50005e7a28awk3o6n",
+    projectId: "cljizf1or0253q1a2rhq197uz",
+  },
+  reportId: "7e639915-54d1-4a6e-9a7e-98f94e270876",
+  calculated: {
+    promptCost: 0.000098,
+    completionCost: 0.000124,
+    totalCost: 0.000222,
+    totalTokens: 127,
+    duration: 2600,
+  },
+  provider: "OpenAI",
+  type: "ChatCompletion",
+  metadata: { conversationId: "task-generator" },
+  request: {
+    timestamp: "2023-06-30T20:00:59.437Z",
+    body: {
+      model: "gpt-3.5-turbo",
+      temperature: 0,
+      max_tokens: 1000,
+      messages: [],
+    },
+  },
+  response: {
+    timestamp: "2023-06-30T20:01:02.037Z",
+    body: {
+      id: "chatcmpl-7XEaZV94h0bdNGr9p5FaMGj2MWiZ0",
+      object: "chat.completion",
+      created: 1688155259,
+      model: "gpt-3.5-turbo-0613",
+      choices: [],
+      usage: {},
+    },
+    status: 200,
+  },
+};
+
+export function validateKey(obj, key) {
+  const keys = key.split(".");
+  let currentObj = obj;
+
+  for (let i = 0; i < keys.length; i++) {
+    const currentKey = keys[i];
+
+    // eslint-disable-next-line no-prototype-builtins
+    if (!currentObj.hasOwnProperty(currentKey)) {
+      return false;
+    }
+
+    currentObj = currentObj[currentKey];
+  }
+
+  return true;
+}
+
+export const mapFiltersToDql = ({
+  projectId,
+  organizationId,
+  filters,
+  sort,
+}: {
+  projectId: string;
+  organizationId: string;
+  filters?: FilterInput[];
+  sort?: SortInput;
+}) => {
+  let body = bodybuilder()
+    .query("match", "ownership.projectId", projectId)
+    .query("match", "ownership.organizationId", organizationId);
+
+  if (sort) {
+    body = body.sort(sort.field, sort.direction);
+  } else {
+    body = body.sort("request.timestamp", "desc");
+  }
+
+  filters.forEach((filter) => {
+    if (!validateKey(exampleReport, filter.field)) return;
+
+    switch (filter.operator) {
+      case FilterOperator.eq:
+        body = body.filter("term", filter.field, filter.value);
+        break;
+      case FilterOperator.neq:
+        body = body.notFilter("term", filter.field, filter.value);
+        break;
+      case FilterOperator.in:
+        // Ensure that filter.value is an array for 'in' operator
+        if (!Array.isArray(filter.value)) {
+          throw new Error(`Operator 'in' requires an array of values.`);
+        }
+        body = body.filter("terms", filter.field, filter.value);
+        break;
+      case FilterOperator.nin:
+        // Ensure that filter.value is an array for 'nin' operator
+        if (!Array.isArray(filter.value)) {
+          throw new Error(`Operator 'nin' requires an array of values.`);
+        }
+        body = body.notFilter("terms", filter.field, filter.value);
+        break;
+      case FilterOperator.contains:
+        body = body.query("match", filter.field, filter.value);
+        break;
+      case FilterOperator.gt:
+      case FilterOperator.gte:
+      case FilterOperator.lt:
+      case FilterOperator.lte:
+        body = body.filter("range", filter.field, {
+          [filter.operator]: filter.value,
+        });
+        break;
+      default:
+        throw new Error(`Unknown filter operator: ${filter.operator}`);
+    }
+  });
+
+  return body.build();
+};

--- a/apps/server/src/app/reporting/utils/dql-utils.ts
+++ b/apps/server/src/app/reporting/utils/dql-utils.ts
@@ -2,62 +2,39 @@ import { FilterInput, FilterOperator } from "../../common/filters/filter.input";
 import { SortInput } from "../../common/filters/sort.input";
 import bodybuilder from "bodybuilder";
 
-const exampleReport = {
-  ownership: {
-    organizationId: "cljdau1v50005e7a28awk3o6n",
-    projectId: "cljizf1or0253q1a2rhq197uz",
-  },
-  reportId: "7e639915-54d1-4a6e-9a7e-98f94e270876",
-  calculated: {
-    promptCost: 0.000098,
-    completionCost: 0.000124,
-    totalCost: 0.000222,
-    totalTokens: 127,
-    duration: 2600,
-  },
-  provider: "OpenAI",
-  type: "ChatCompletion",
-  metadata: { conversationId: "task-generator" },
-  request: {
-    timestamp: "2023-06-30T20:00:59.437Z",
-    body: {
-      model: "gpt-3.5-turbo",
-      temperature: 0,
-      max_tokens: 1000,
-      messages: [],
-    },
-  },
-  response: {
-    timestamp: "2023-06-30T20:01:02.037Z",
-    body: {
-      id: "chatcmpl-7XEaZV94h0bdNGr9p5FaMGj2MWiZ0",
-      object: "chat.completion",
-      created: 1688155259,
-      model: "gpt-3.5-turbo-0613",
-      choices: [],
-      usage: {},
-    },
-    status: 200,
-  },
-};
-
-export function validateKey(obj, key) {
-  const keys = key.split(".");
-  let currentObj = obj;
-
-  for (let i = 0; i < keys.length; i++) {
-    const currentKey = keys[i];
-
-    // eslint-disable-next-line no-prototype-builtins
-    if (!currentObj.hasOwnProperty(currentKey)) {
-      return false;
-    }
-
-    currentObj = currentObj[currentKey];
-  }
-
-  return true;
-}
+const validFields = new Set([
+  "ownership",
+  "ownership.organizationId",
+  "ownership.projectId",
+  "reportId",
+  "calculated",
+  "calculated.promptCost",
+  "calculated.completionCost",
+  "calculated.totalCost",
+  "calculated.totalTokens",
+  "calculated.duration",
+  "provider",
+  "type",
+  "properties",
+  "metadata",
+  "request",
+  "request.timestamp",
+  "request.body",
+  "request.body.model",
+  "request.body.temperature",
+  "request.body.max_tokens",
+  "request.body.messages",
+  "response",
+  "response.timestamp",
+  "response.body",
+  "response.body.id",
+  "response.body.object",
+  "response.body.created",
+  "response.body.model",
+  "response.body.choices",
+  "response.body.usage",
+  "response.status",
+]);
 
 export const mapFiltersToDql = ({
   projectId,
@@ -74,14 +51,14 @@ export const mapFiltersToDql = ({
     .query("match", "ownership.projectId", projectId)
     .query("match", "ownership.organizationId", organizationId);
 
-  if (sort) {
+  if (sort != null) {
     body = body.sort(sort.field, sort.direction);
   } else {
     body = body.sort("request.timestamp", "desc");
   }
 
   filters.forEach((filter) => {
-    if (!validateKey(exampleReport, filter.field)) return;
+    if (!validFields.has(filter.field)) return;
 
     switch (filter.operator) {
       case FilterOperator.eq:

--- a/examples/task-generator-app/app/api/tasks/route.ts
+++ b/examples/task-generator-app/app/api/tasks/route.ts
@@ -41,14 +41,12 @@ export async function POST(request: Request) {
 
     result = await openai.createChatCompletion(reqBody);
 
-    // const parsed = JSON.parse(result.data.choices[0].message.content);
     // TODO: this is a temporary place holder for as long as we fix the git state issues
     const parsed = JSON.parse(result.data.choices[0].message.content);
     return NextResponse.json(parsed, {
       headers: { "Content-Type": "application/json" },
     });
   } catch (error) {
-
     let message;
 
     if (error.response?.errors) {

--- a/examples/task-generator-app/app/lib/pezzo.ts
+++ b/examples/task-generator-app/app/lib/pezzo.ts
@@ -1,11 +1,12 @@
 import { Pezzo, PezzoOpenAIApi } from "@pezzo/client";
 import { Configuration } from "openai";
+import * as process from "process";
 
 // Initialize the Pezzo client
 export const pezzo = new Pezzo({
   serverUrl: process.env.PEZZO_SERVER_URL || "https://api.pezzo.ai",
   apiKey: process.env.PEZZO_API_KEY as string,
-  projectId: "cljh8ibei0066nyph2sj0xerd",
+  projectId: process.env.PEZZO_PROJECT_ID as string,
   environment: "Production",
 });
 
@@ -16,4 +17,3 @@ const configuration = new Configuration({
 
 // Initialize the Pezzo OpenAI API
 export const openai = new PezzoOpenAIApi(pezzo, configuration);
-

--- a/libs/client/src/client/Pezzo.ts
+++ b/libs/client/src/client/Pezzo.ts
@@ -94,7 +94,6 @@ export class Pezzo {
     url.searchParams.append("name", promptName);
     url.searchParams.append("environmentName", this.options.environment);
 
-
     const response = await fetch(url.toString(), {
       headers: {
         "Content-Type": "application/json",
@@ -135,8 +134,6 @@ export class Pezzo {
   }
 
   async reportPromptExecutionV2(dto: ReportData) {
-
-
     await axios.post(
       `${this.options.serverUrl}/api/reporting/v2/request`,
       dto,

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "antd": "^5.4.5",
         "apollo-server-errors": "^3.3.1",
         "apollo-server-express": "^3.12.0",
+        "bodybuilder": "^2.5.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "date-fns": "^2.30.0",
@@ -12759,6 +12760,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/bodybuilder": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bodybuilder/-/bodybuilder-2.5.0.tgz",
+      "integrity": "sha512-n9Cpi/qKH7FfFe3WHRC/jYBQt/vtkPmCuDdIM53lARoWHVDGEc5d55erKZE/dxzv0dY+ioKcd+C8EY+AytBlSw==",
+      "dependencies": {
+        "lodash.clonedeep": "4.5.0",
+        "lodash.isobject": "3.0.2",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.merge": "4.6.2",
+        "lodash.set": "4.3.2",
+        "lodash.unset": "4.5.2"
+      }
+    },
     "node_modules/bonjour-service": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
@@ -23417,6 +23431,16 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -23425,8 +23449,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "devOptional": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.omit": {
       "version": "4.5.0",
@@ -23439,6 +23462,11 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -23448,6 +23476,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "node_modules/lodash.unset": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
+      "integrity": "sha512-bwKX88k2JhCV9D1vtE8+naDKlLiGrSmf8zi/Y9ivFHwbmRfA8RxS/aVJ+sIht2XOwqoNr4xUPUkGZpc1sHFEKg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -40422,6 +40455,19 @@
         }
       }
     },
+    "bodybuilder": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bodybuilder/-/bodybuilder-2.5.0.tgz",
+      "integrity": "sha512-n9Cpi/qKH7FfFe3WHRC/jYBQt/vtkPmCuDdIM53lARoWHVDGEc5d55erKZE/dxzv0dY+ioKcd+C8EY+AytBlSw==",
+      "requires": {
+        "lodash.clonedeep": "4.5.0",
+        "lodash.isobject": "3.0.2",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.merge": "4.6.2",
+        "lodash.set": "4.3.2",
+        "lodash.unset": "4.5.2"
+      }
+    },
     "bonjour-service": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
@@ -48546,6 +48592,16 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -48554,8 +48610,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "devOptional": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -48568,6 +48623,11 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -48577,6 +48637,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "lodash.unset": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
+      "integrity": "sha512-bwKX88k2JhCV9D1vtE8+naDKlLiGrSmf8zi/Y9ivFHwbmRfA8RxS/aVJ+sIht2XOwqoNr4xUPUkGZpc1sHFEKg=="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "antd": "^5.4.5",
     "apollo-server-errors": "^3.3.1",
     "apollo-server-express": "^3.12.0",
+    "bodybuilder": "^2.5.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "date-fns": "^2.30.0",


### PR DESCRIPTION
This PR introduces filtering and DQL abilities in pezzo console & backend.

The idea is as follows:
Each sort/filter is represented in URL query params. The frontend client should be able to set these url parameters, and a hook implemented as part of this PR is able to read them interpret each and reorder to send to the backend.
The backend GQL is now able to take these filters (and sort), read them and translate them into opensearch DQL using `bodybuilder` library.
They are applied per request from opensearch, which then returns filtered results.

An example of how filters are requested:
`http://localhost:4200/projects/cljizf1or0253q1a2rhq197uz/requests?sort=request.timestamp:asc&f=calculated.totalTokens:gte:126&f=calculated.totalTokens:lt:127`

In this URL, you can see we have 3 different queries:
1. `sort` query on `request.timestamp` field, ascending
2. `f` (for filter) request on `calculated.totalTokens` field, `gte` operator and the value 126
3. `f` (for filter) request on `calculated.totalTokens` field, `lt` operator and the value 127

A sort request structure in the URL is made with the `sort` query param key and takes arguments using the following schema: `field:direction (asc/desc)`
A filter request structure in the URL is made with the `f` query param key and takes arguments using the following schema: `field:operator:value1:value2` where value2 is optional

The idea behind the filtering here is to pile them on top of each it. So for example, if I'd like to filter for a value that is greater than 2 but lower than 5, I should usually include two filters:
1. Greater than 2
2. Lower than 5
This approach allows for a more flexible and comprehensive filtering system without the need to introduce many operators.


Validation and the runtime issue:
One of the things we want to do, is to validate the field names a user is inserting (probably among other things).
The problem is, we need to validate it on runtime, and the only data we have on the fields ATM is build time data (aka TS class).
For this reason, we need to introduce hardcoded expected runtime data to validate against.
There are two ways to handle this, each is part of one of two commits currently in this PR:
1. Add an example payload, read its keys and nested keys and see if the field in filter request matches any of these. If it does not, the filter is ignored.
2. Keep a hardcoded list of the fields we are allowing. Check if the field in filter request is present in this list. If it isn't, the filter is ignored.