### PR TITLE
fix(console): "TEST" label shows only for test prompts

### DIFF
--- a/apps/console/src/app/pages/requests/RequestsPage.tsx
+++ b/apps/console/src/app/pages/requests/RequestsPage.tsx
@@ -59,9 +59,8 @@ const getTableColumns = (
     columns.unshift({
       title: "",
       dataIndex: "isTestPrompt",
-      render: (isTestPrmopt: string) => (
-        <Tag color={colors.neutral[600]}>TEST</Tag>
-      ),
+      render: (isTestPrompt: boolean) =>
+        isTestPrompt && <Tag color={colors.neutral[600]}>TEST</Tag>,
       width: "40px",
       align: "center",
     });


### PR DESCRIPTION
This PR fixes an issue where the "TEST" label in the Requests tab shows for all prompts if there's at least one test request.