### PR TITLE
fix(client): openai chat completion return type

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pezzo/client",
   "description": "TypeScript API client for Pezzo",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "commonjs",
   "author": "Ariel Weinberger",
   "keywords": [

--- a/libs/client/src/client/PezzoOpenAI.ts
+++ b/libs/client/src/client/PezzoOpenAI.ts
@@ -52,7 +52,7 @@ class Completions {
     optionsOrPezzoProps:
       | Parameters<OpenAI["chat"]["completions"]["create"]>[1]
       | PezzoProps = {}
-  ) {
+  ): Promise<OpenAI.Chat.ChatCompletion> {
     const arg1 = _arg1 as PezzoCreateChatCompletionRequest;
 
     const pezzoPrompt = arg1.pezzo as any; // TODO: Fix this type

--- a/libs/client/src/version.ts
+++ b/libs/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.4.9";
+export const version = "0.4.10";


### PR DESCRIPTION
Return the correct type from `openai.chat.completions.create`