### PR TITLE
feat: warp non-antd icons with `<Icon/>`

### DIFF
--- a/apps/console/src/app/components/layout/Header.tsx
+++ b/apps/console/src/app/components/layout/Header.tsx
@@ -45,11 +45,7 @@ const menuItems: MenuProps["items"] = [
           <Typography.Text>Info</Typography.Text>
         </Col>
         <Col style={{ marginLeft: "auto" }}>
-          <Icon
-            component={() => (
-              <QuestionMarkCircleIcon width={15} /> 
-            )}
-          />
+          <Icon component={() => <QuestionMarkCircleIcon width={15} />} />
         </Col>
       </Row>
     ),

--- a/apps/console/src/app/components/layout/Header.tsx
+++ b/apps/console/src/app/components/layout/Header.tsx
@@ -21,6 +21,7 @@ import { signOut } from "../../lib/utils/sign-out";
 import { useNavigate } from "react-router-dom";
 import { Avatar } from "../common/Avatar";
 import { OrgSelector } from "../organizations/OrgSelector";
+import Icon from "@ant-design/icons/lib/components/Icon";
 
 const Logo = styled.img`
   height: 40px;
@@ -44,7 +45,11 @@ const menuItems: MenuProps["items"] = [
           <Typography.Text>Info</Typography.Text>
         </Col>
         <Col style={{ marginLeft: "auto" }}>
-          <QuestionMarkCircleIcon height={16} />
+          <Icon
+            component={() => (
+              <QuestionMarkCircleIcon width={15} /> 
+            )}
+          />
         </Col>
       </Row>
     ),
@@ -57,7 +62,7 @@ const menuItems: MenuProps["items"] = [
           <Typography.Text>Sign out</Typography.Text>
         </Col>
         <Col style={{ marginLeft: "auto" }}>
-          <ArrowRightOnRectangleIcon height={16} />
+          <Icon component={() => <ArrowRightOnRectangleIcon width={15} />} />
         </Col>
       </Row>
     ),

--- a/apps/console/src/app/components/layout/SideNavigation.tsx
+++ b/apps/console/src/app/components/layout/SideNavigation.tsx
@@ -1,39 +1,37 @@
 import {
   ChatBubbleBottomCenterIcon,
   HomeIcon,
+  AcademicCapIcon,
+  CubeIcon,
+  ServerIcon,
 } from "@heroicons/react/24/outline";
 import { Menu } from "antd";
 import { useMemo, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import styled from "@emotion/styled";
-
+import Icon from "@ant-design/icons/lib/components/Icon";
 import { useCurrentProject } from "../../lib/hooks/useCurrentProject";
-import {
-  AcademicCapIcon,
-  CubeIcon,
-  ServerIcon,
-} from "@heroicons/react/24/outline";
 
 const topMenuItems = [
   {
     key: "dashboard",
     label: "Dashboard",
-    icon: <HomeIcon height={18} />,
+    icon: <Icon component={() => <HomeIcon width={15} />} />,
   },
   {
     key: "requests",
     label: "Requests",
-    icon: <ChatBubbleBottomCenterIcon height={18} width={18} />,
+    icon: <Icon component={() => <ChatBubbleBottomCenterIcon width={15} />} />,
   },
   {
     key: "prompts",
     label: "Prompts",
-    icon: <CubeIcon height={18} />,
+    icon: <Icon component={() => <CubeIcon width={15} />} />,
   },
   {
     key: "environments",
     label: "Environments",
-    icon: <ServerIcon height={18} />,
+    icon: <Icon component={() => <ServerIcon width={15} />} />,
   },
 ];
 
@@ -88,7 +86,10 @@ export const SideNavigation = () => {
       />
       {/* Bottom Menu */}
       <BaseMenu inlineCollapsed={isCollapsed} mode="inline">
-        <Menu.Item key="docs" icon={<AcademicCapIcon height={18} />}>
+        <Menu.Item
+          key="docs"
+          icon={<Icon component={() => <AcademicCapIcon width={15} />} />}
+        >
           <a href="https://docs.pezzo.ai/" target="_blank" rel="noreferrer">
             <span>Docs</span>
           </a>

--- a/apps/console/src/app/components/layout/SideNavigation.tsx
+++ b/apps/console/src/app/components/layout/SideNavigation.tsx
@@ -16,22 +16,49 @@ const topMenuItems = [
   {
     key: "dashboard",
     label: "Dashboard",
-    icon: <Icon component={() => <HomeIcon width={15} />} />,
+    icon: (
+      <Icon
+        component={() => (
+          <HomeIcon width={20} style={{ marginTop: 10, marginLeft: -2 }} />
+        )}
+      />
+    ),
   },
   {
     key: "requests",
     label: "Requests",
-    icon: <Icon component={() => <ChatBubbleBottomCenterIcon width={15} />} />,
+    icon: (
+      <Icon
+        component={() => (
+          <ChatBubbleBottomCenterIcon
+            width={20}
+            style={{ marginTop: 10, marginLeft: -2 }}
+          />
+        )}
+      />
+    ),
   },
   {
     key: "prompts",
     label: "Prompts",
-    icon: <Icon component={() => <CubeIcon width={15} />} />,
+    icon: (
+      <Icon
+        component={() => (
+          <CubeIcon width={20} style={{ marginTop: 10, marginLeft: -2 }} />
+        )}
+      />
+    ),
   },
   {
     key: "environments",
     label: "Environments",
-    icon: <Icon component={() => <ServerIcon width={15} />} />,
+    icon: (
+      <Icon
+        component={() => (
+          <ServerIcon width={20} style={{ marginTop: 10, marginLeft: -2 }} />
+        )}
+      />
+    ),
   },
 ];
 

--- a/apps/console/src/app/components/projects/ProjectCard.tsx
+++ b/apps/console/src/app/components/projects/ProjectCard.tsx
@@ -27,7 +27,9 @@ export const ProjectCard = ({ name, slug, id }: ProjectCardProps) => {
           {name}
         </Typography.Title>
 
-        <Icon component={() => <ArrowRightCircleIcon width={15} />} />
+        <Icon
+          component={() => <ArrowRightCircleIcon height={24} opacity={0.5} />}
+        />
       </Row>
     </Card>
   );

--- a/apps/console/src/app/components/projects/ProjectCard.tsx
+++ b/apps/console/src/app/components/projects/ProjectCard.tsx
@@ -29,7 +29,7 @@ export const ProjectCard = ({ name, slug, id }: ProjectCardProps) => {
 
         <Icon
           component={() => (
-            <ArrowRightCircleIcon width={15} /> // Setting width to 15px seems to work well for most use cases
+            <ArrowRightCircleIcon width={15} />
           )}
         />
       </Row>

--- a/apps/console/src/app/components/projects/ProjectCard.tsx
+++ b/apps/console/src/app/components/projects/ProjectCard.tsx
@@ -2,6 +2,7 @@ import { ArrowRightCircleIcon } from "@heroicons/react/24/outline";
 import { Card, Row, Typography } from "antd";
 import { useNavigate } from "react-router-dom";
 import { trackEvent } from "../../lib/utils/analytics";
+import Icon from "@ant-design/icons/lib/components/Icon";
 
 interface ProjectCardProps {
   name: string;
@@ -26,7 +27,11 @@ export const ProjectCard = ({ name, slug, id }: ProjectCardProps) => {
           {name}
         </Typography.Title>
 
-        <ArrowRightCircleIcon opacity={0.5} height={24} />
+        <Icon
+          component={() => (
+            <ArrowRightCircleIcon width={15} /> // Setting width to 15px seems to work well for most use cases
+          )}
+        />
       </Row>
     </Card>
   );

--- a/apps/console/src/app/components/projects/ProjectCard.tsx
+++ b/apps/console/src/app/components/projects/ProjectCard.tsx
@@ -27,11 +27,7 @@ export const ProjectCard = ({ name, slug, id }: ProjectCardProps) => {
           {name}
         </Typography.Title>
 
-        <Icon
-          component={() => (
-            <ArrowRightCircleIcon width={15} />
-          )}
-        />
+        <Icon component={() => <ArrowRightCircleIcon width={15} />} />
       </Row>
     </Card>
   );

--- a/apps/console/src/app/components/prompts/PromptListItem.tsx
+++ b/apps/console/src/app/components/prompts/PromptListItem.tsx
@@ -37,7 +37,9 @@ export const PromptListItem = ({ name, isDraft, onClick }: Props) => {
             justify-content: flex-end;
           `}
         >
-          <Icon component={() => <ArrowRightCircleIcon width={15} />} />
+          <Icon
+            component={() => <ArrowRightCircleIcon height={24} opacity={0.5} />}
+          />
         </Col>
       </Row>
     </Card>

--- a/apps/console/src/app/components/prompts/PromptListItem.tsx
+++ b/apps/console/src/app/components/prompts/PromptListItem.tsx
@@ -2,6 +2,7 @@ import { ArrowRightCircleIcon, CubeIcon } from "@heroicons/react/24/outline";
 import { Card, Col, Row, Tag, Typography } from "antd";
 import { css } from "@emotion/css";
 import { colorPrimary } from "../../lib/theme/ant-theme";
+import Icon from "@ant-design/icons/lib/components/Icon";
 
 interface Props {
   name: string;
@@ -36,7 +37,7 @@ export const PromptListItem = ({ name, isDraft, onClick }: Props) => {
             justify-content: flex-end;
           `}
         >
-          <ArrowRightCircleIcon opacity={0.5} height={24} />
+          <Icon component={() => <ArrowRightCircleIcon width={15} />} />
         </Col>
       </Row>
     </Card>

--- a/apps/console/src/app/components/requests/RequestDetails.tsx
+++ b/apps/console/src/app/components/requests/RequestDetails.tsx
@@ -26,6 +26,7 @@ import { useState } from "react";
 import { RequestResponseChatView } from "./RequestResponseChatView";
 import { RequestResponseViewJsonView } from "./RequestResponseViewJsonView";
 import { trackEvent } from "../../lib/utils/analytics";
+import Icon from "@ant-design/icons/lib/components/Icon";
 
 type Mode = "chat" | "json";
 
@@ -142,12 +143,18 @@ export const RequestDetails = (props: Props) => {
         <Segmented
           options={[
             {
-              icon: <ChatBubbleBottomCenterTextIcon width={18} height={14} />,
+              icon: (
+                <Icon
+                  component={() => (
+                    <ChatBubbleBottomCenterTextIcon width={15} />
+                  )}
+                />
+              ),
               value: "chat",
               label: "Chat",
             },
             {
-              icon: <CodeBracketIcon width={18} height={14} />,
+              icon: <Icon component={() => <CodeBracketIcon width={15} />} />,
               value: "json",
               label: "JSON",
             },

--- a/apps/console/src/app/components/requests/RequestResponseChatView.tsx
+++ b/apps/console/src/app/components/requests/RequestResponseChatView.tsx
@@ -1,4 +1,5 @@
 import { UserCircleIcon } from "@heroicons/react/24/solid";
+import Icon from "@ant-design/icons/lib/components/Icon";
 import {
   ObservabilityRequest,
   ObservabilityResponse,
@@ -30,7 +31,12 @@ export const RequestResponseChatView = ({ request, response }: Props) => {
   const renderAvatar = (role: "user" | "system" | "assistant") => {
     switch (role) {
       case "user":
-        return <Avatar shape="circle" src={<UserCircleIcon />} />;
+        return (
+          <Avatar
+            shape="circle"
+            src={<Icon component={() => <UserCircleIcon width={15} />} />}
+          />
+        );
       case "system":
         return <Avatar shape="circle">S</Avatar>;
       case "assistant":

--- a/apps/console/src/app/components/requests/RequestResponseChatView.tsx
+++ b/apps/console/src/app/components/requests/RequestResponseChatView.tsx
@@ -34,7 +34,7 @@ export const RequestResponseChatView = ({ request, response }: Props) => {
         return (
           <Avatar
             shape="circle"
-            src={<Icon component={() => <UserCircleIcon width={15} />} />}
+            src={<Icon component={() => <UserCircleIcon width={"100%"} />} />}
           />
         );
       case "system":


### PR DESCRIPTION
Fixes #203 

Everywhere the @heroicons import was used, I wrapped the non-antd icons with the Icon tag, as demonstrated in the issue.
Issue: https://github.com/pezzolabs/pezzo/issues/203

I did have some troubles running the project, so I was not able to check if the width of the icons was fitting:
The error:
<img width="562" alt="Screenshot 2023-09-18 at 20 58 46" src="https://github.com/pezzolabs/pezzo/assets/30553945/3a5a0d8e-731c-4130-997e-8f3a5f4eec69">

