### PR TITLE
Fixing regex and password validation message during registration

### DIFF
--- a/apps/console/src/app/pages/auth/LoginPage.tsx
+++ b/apps/console/src/app/pages/auth/LoginPage.tsx
@@ -49,8 +49,8 @@ export const LoginPage = () => {
       password: z
         .string()
         .regex(
-          /^(?=.*[A-Z])(?=.*[!@#$%^&*()_+{}[\]:;<>,.?~\\-]).{8,}$/,
-          "Password must contain at least 8 characters, one uppercase, one lowercase and one number"
+          /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()_+{}[\]:;<>,.?~\\-]).{8,}$/,
+          "Password must contain at least 8 characters, one uppercase, one lowercase, one number, and one special symbol"
         ),
       confirm_password: z.string().min(1, "Confirm password is required"),
       name: z.string().min(1, "Display name is required"),


### PR DESCRIPTION
Fixes #218 

This regular expression will enforce the specified password requirements. It checks for the presence of at least one uppercase letter ((?=.*[A-Z])), one lowercase letter ((?=.*[a-z])), one digit ((?=.*\d)), and one special symbol ((?=.*[!@#$%^&*()_+{}[\]:;<>,.?~\\-])). Additionally, it ensures that the total length of the password is at least 8 characters (.{8,}).