### PR TITLE
fix: use provided project ID in `getDeployedPrompt` (REST API)

### DIFF
--- a/apps/server/src/app/prompts/dto/get-prompt-deployment.dto.ts
+++ b/apps/server/src/app/prompts/dto/get-prompt-deployment.dto.ts
@@ -1,4 +1,4 @@
-import { IsString } from "class-validator";
+import { IsOptional, IsString } from "class-validator";
 
 export class GetPromptDeploymentDto {
   @IsString()
@@ -6,4 +6,8 @@ export class GetPromptDeploymentDto {
 
   @IsString()
   environmentName: string;
+
+  @IsString()
+  @IsOptional() // Backwards compatibility - https://github.com/pezzolabs/pezzo/issues/224
+  projectId: string;
 }

--- a/apps/server/src/app/prompts/dto/get-prompt-deployment.dto.ts
+++ b/apps/server/src/app/prompts/dto/get-prompt-deployment.dto.ts
@@ -6,8 +6,4 @@ export class GetPromptDeploymentDto {
 
   @IsString()
   environmentName: string;
-
-  @IsString()
-  @IsOptional() // Backwards compatibility - https://github.com/pezzolabs/pezzo/issues/224
-  projectId: string;
 }

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pezzo/client",
   "description": "TypeScript API client for Pezzo",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "type": "commonjs",
   "author": "Ariel Weinberger",
   "keywords": [

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pezzo/client",
   "description": "TypeScript API client for Pezzo",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "commonjs",
   "author": "Ariel Weinberger",
   "keywords": [

--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pezzo/client",
   "description": "TypeScript API client for Pezzo",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "type": "commonjs",
   "author": "Ariel Weinberger",
   "keywords": [

--- a/libs/client/src/client/Pezzo.ts
+++ b/libs/client/src/client/Pezzo.ts
@@ -37,6 +37,7 @@ export class Pezzo {
     const url = new URL(`${this.options.serverUrl}/api/prompts/v2/deployment`);
     url.searchParams.append("name", promptName);
     url.searchParams.append("environmentName", this.options.environment);
+    url.searchParams.append("projectId", this.options.projectId);
 
     const response = await fetch(url.toString(), {
       headers: {

--- a/libs/client/src/client/Pezzo.ts
+++ b/libs/client/src/client/Pezzo.ts
@@ -37,12 +37,12 @@ export class Pezzo {
     const url = new URL(`${this.options.serverUrl}/api/prompts/v2/deployment`);
     url.searchParams.append("name", promptName);
     url.searchParams.append("environmentName", this.options.environment);
-    url.searchParams.append("projectId", this.options.projectId);
 
     const response = await fetch(url.toString(), {
       headers: {
         "Content-Type": "application/json",
         "x-pezzo-api-key": this.options.apiKey,
+        "x-pezzo-project-id": this.options.projectId,
       },
     });
     const data = await response.json();

--- a/libs/client/src/version.ts
+++ b/libs/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.4.11";
+export const version = "0.4.12";

--- a/libs/client/src/version.ts
+++ b/libs/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.4.12";
+export const version = "0.4.13";

--- a/libs/client/src/version.ts
+++ b/libs/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.4.13";
+export const version = "0.4.14";


### PR DESCRIPTION
fixes #224 