### PR TITLE
Fix OpenAPI relative path for prod - Mintlify

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -111,5 +111,5 @@
       "mode": "hide"
     }
   },
-  "openapi": "./openapi.json"
+  "openapi": "/openapi.json"
 }


### PR DESCRIPTION
What is this pull request for?
It fixes the broken API reference on production. Turns out, Mintlify auto-detects the spec file in development environment but fails in production.


### Screenshot of the problem:
![image](https://github.com/pezzolabs/pezzo/assets/62343225/d8799676-0711-4361-83fb-7a6e21da5544)
