### PR TITLE
fix(server): updated correct promptsService in deletePrompt mutation

### DIFF
--- a/apps/server/src/app/prompts/prompts.resolver.ts
+++ b/apps/server/src/app/prompts/prompts.resolver.ts
@@ -243,7 +243,7 @@ export class PromptsResolver {
     const { id } = data;
     this.logger.assign({ id }).info("Deleting prompt");
 
-    let prompt = await this.promptsService.deletePrompt(id);
+    let prompt = await this.promptsService.getPrompt(id);
     const org = await this.organizationsService.getOrgByProjectId(
       prompt.projectId
     );


### PR DESCRIPTION
Fixes #235 

To fetch prompt data it was using wrong prompt service (promptsService.deletePrompt) which was causing the error while we were deleting the prompt and in try catch block it was again calling (promptsService.deletePrompt).