### PR TITLE
feat(console): display environment name in report

### DIFF
--- a/apps/console/src/app/components/requests/RequestDetails.tsx
+++ b/apps/console/src/app/components/requests/RequestDetails.tsx
@@ -134,6 +134,10 @@ export const RequestDetails = (props: Props) => {
       ),
     },
     {
+      title: "Environment",
+      description: props.metadata.environment,
+    },
+    {
       title: "Duration",
       description: ms(props.calculated.duration),
     },

--- a/apps/console/src/app/components/requests/RequestResponseChatView.tsx
+++ b/apps/console/src/app/components/requests/RequestResponseChatView.tsx
@@ -13,9 +13,7 @@ import {
   Row,
   Col,
   Avatar,
-  Tag,
   Tooltip,
-  Card,
 } from "antd";
 import OpenAILogo from "../../../assets/providers/openai-logo.svg";
 

--- a/libs/types/src/request.ts
+++ b/libs/types/src/request.ts
@@ -15,6 +15,7 @@ export type ObservabilityReportMetadata = {
   provider: Provider;
   client?: string;
   clientVersion?: string;
+  environment: string;
   type: PromptExecutionType;
   [key: string]: AllPrimitiveTypes;
 };


### PR DESCRIPTION
Add an "Environment" field in the report side panel.

![image](https://github.com/pezzolabs/pezzo/assets/4976416/396a7a2c-4f52-4064-a048-aa2024a18af3)
