### PR TITLE
feat(console): support rendering of images

### DIFF
--- a/apps/console/src/components/prompts/prompt-tester/PromptTesterModal.tsx
+++ b/apps/console/src/components/prompts/prompt-tester/PromptTesterModal.tsx
@@ -8,7 +8,6 @@ import {
   AlertTitle,
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@pezzo/ui";
@@ -32,14 +31,11 @@ export const PromptTesterModal = () => {
   return (
     <Dialog open={isOpen}>
       <DialogContent
-        onPointerDownOutside={closeTestModal}
-        className={cn({
+        onPointerDownOutside={handleCancel}
+        className={cn("p-0", {
           "max-w-3xl": testResult,
         })}
       >
-        <DialogHeader>
-          <DialogTitle>Prompt Tester</DialogTitle>
-        </DialogHeader>
         <div>
           {testError && (
             <Alert variant="destructive" className="mb-4">
@@ -54,6 +50,7 @@ export const PromptTesterModal = () => {
           {testResult && (
             <div className="w-full">
               <RequestDetails
+                disableCopy
                 id={testResult.reportId}
                 request={testResult.request}
                 response={testResult.response}

--- a/apps/console/src/components/requests/RequestDetails.tsx
+++ b/apps/console/src/components/requests/RequestDetails.tsx
@@ -39,6 +39,7 @@ import { useCopyToClipboard } from "usehooks-ts";
 type Mode = "chat" | "json";
 
 interface Props {
+  disableCopy?: boolean;
   id: string;
   request: ObservabilityRequest;
   response: ObservabilityResponse;
@@ -62,6 +63,7 @@ const getClientDisplayName = (client: string) => {
 };
 
 export const RequestDetails = (props: Props) => {
+  const disableCopy = props.disableCopy || false;
   const request = props.request as ObservabilityRequest<Provider.OpenAI>;
   const response = props.response as ObservabilityResponse<Provider.OpenAI>;
   const isSuccess = response.status >= 200 && response.status < 300;
@@ -110,11 +112,11 @@ export const RequestDetails = (props: Props) => {
     },
     {
       title: "Provider",
-      description: <>{props.provider}</>,
+      description: props.provider,
     },
     {
       title: "Model",
-      description: <>{request.body.model}</>,
+      description: request.body.model,
     },
     {
       title: "Tokens",
@@ -181,28 +183,6 @@ export const RequestDetails = (props: Props) => {
       title: "Duration",
       description: ms(props.calculated.duration),
     },
-    {
-      title: "Display mode",
-      description: (
-        <Tabs
-          value={selectedMode}
-          onValueChange={(value: Mode) => handleDisplayModeChange(value)}
-        >
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger
-              disabled={!isSuccess}
-              className="flex gap-1"
-              value="chat"
-            >
-              <MessageSquare className="h-4 w-4" /> Chat
-            </TabsTrigger>
-            <TabsTrigger className="flex gap-1" value="json">
-              <BracesIcon className="h-4 w-4" /> JSON
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
-      ),
-    },
   ];
 
   const renderResponse = () => {
@@ -219,53 +199,80 @@ export const RequestDetails = (props: Props) => {
   };
 
   return (
-    <div className="p-4 text-sm">
-      <div className="flex items-center justify-between">
+    <div className=" text-sm">
+      <div className="flex items-center justify-between border-b p-4">
         <h3>Request Details</h3>
-        <div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              copy(window.location.href);
-            }}
-          >
-            {!copied && (
-              <>
-                <Link className="mr-2 h-4 w-4" /> Copy Link
-              </>
-            )}
 
-            {copied && (
-              <>
-                <CheckIcon className="mr-2 h-4 w-4" /> Copied
-              </>
-            )}
-          </Button>
-        </div>
+        {!disableCopy && (
+          <div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                copy(window.location.href);
+              }}
+            >
+              {!copied && (
+                <>
+                  <Link className="mr-2 h-4 w-4" /> Copy Link
+                </>
+              )}
+
+              {copied && (
+                <>
+                  <CheckIcon className="mr-2 h-4 w-4" /> Copied
+                </>
+              )}
+            </Button>
+          </div>
+        )}
       </div>
 
-      {props.metadata?.isTestPrompt && (
-        <Alert className="my-4 border-blue-900 bg-blue-950/40 text-blue-500">
-          <AlertDescription className="flex items-center gap-1">
-            <InfoIcon className="h-4 w-4" />
-            This is a test request from the Pezzo Console
-          </AlertDescription>
-        </Alert>
-      )}
+      <div className="px-4">
+        {props.metadata?.isTestPrompt && (
+          <Alert className="my-4 border-blue-900 bg-blue-950/40 text-blue-500">
+            <AlertDescription className="flex items-center gap-1">
+              <InfoIcon className="h-4 w-4" />
+              This is a test request from the Pezzo Console
+            </AlertDescription>
+          </Alert>
+        )}
 
-      <div className="flex flex-col gap-1">
-        {listData.map((item) => (
-          <div
-            key={item.title}
-            className="flex h-12 items-center justify-between border-b px-4 py-3"
-          >
-            <div className="font-semibold">{item.title}</div>
-            <div>{item.description}</div>
+        <div className="flex flex-col gap-1">
+          {listData.map((item) => (
+            <div
+              key={item.title}
+              className="flex h-12 items-center justify-between border-b py-3"
+            >
+              <div className="font-semibold">{item.title}</div>
+              <div>{item.description}</div>
+            </div>
+          ))}
+
+          <div className="mt-2">
+            <div className="mb-3 flex items-center justify-center">
+              <Tabs
+                value={selectedMode}
+                onValueChange={(value: Mode) => handleDisplayModeChange(value)}
+              >
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger
+                    disabled={!isSuccess}
+                    className="flex gap-1"
+                    value="chat"
+                  >
+                    <MessageSquare className="h-4 w-4" /> Chat
+                  </TabsTrigger>
+                  <TabsTrigger className="flex gap-1" value="json">
+                    <BracesIcon className="h-4 w-4" /> JSON
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div>
+
+            {renderResponse()}
           </div>
-        ))}
-
-        <div className="p-4">{renderResponse()}</div>
+        </div>
       </div>
     </div>
   );

--- a/apps/console/src/features/chat/ChatView.tsx
+++ b/apps/console/src/features/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { Chat } from "./types";
+import { Chat, SubChatMessage } from "./types";
 import {
   Tooltip,
   TooltipContent,
@@ -11,12 +11,34 @@ type Props = {
 };
 
 export const ChatView = ({ chat }: Props) => {
+  const renderSubMessages = (subMessages: SubChatMessage[]) => {
+    return subMessages.map((subMessage, index) => {
+      return (
+        <div className="flex gap-4 border-b pb-3 last:border-b-0 last:pb-0">
+          <div>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>{subMessage.icon}</TooltipTrigger>
+                <TooltipContent className="capitalize">
+                  {subMessage.label}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <div className="flex-1">{subMessage.content}</div>
+        </div>
+      );
+    });
+  };
+
   return (
     <div>
-      <p className="mb-4 font-semibold">Chat</p>
       <div className="rounded-md border">
         {chat.messages.map((message, index) => (
-          <div className="flex items-center gap-4 p-4 first:rounded-t-md last:rounded-b-md odd:bg-black">
+          <div
+            key={index}
+            className="flex gap-4 p-4 first:rounded-t-md last:rounded-b-md odd:bg-black"
+          >
             <div>
               <TooltipProvider>
                 <Tooltip>
@@ -27,7 +49,15 @@ export const ChatView = ({ chat }: Props) => {
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="flex-1">{message.content}</div>
+            <div className="flex-1">
+              {message.subMessages ? (
+                <div className="flex flex-col gap-y-3 border-l pl-4">
+                  {renderSubMessages(message.subMessages)}
+                </div>
+              ) : (
+                message.content
+              )}
+            </div>
           </div>
         ))}
       </div>

--- a/apps/console/src/features/chat/normalizers/openai-normalizer.tsx
+++ b/apps/console/src/features/chat/normalizers/openai-normalizer.tsx
@@ -1,30 +1,37 @@
 import OpenAI from "openai";
-import { Chat, ChatMessage } from "../types";
+import { Chat, ChatMessage, SubChatMessage } from "../types";
 import { Provider } from "@pezzo/types";
 import { cn } from "@pezzo/ui/utils";
-import { BotIcon, UserIcon, WrenchIcon } from "lucide-react";
+import {
+  BotIcon,
+  ImageIcon,
+  TypeIcon,
+  UserIcon,
+  WrenchIcon,
+} from "lucide-react";
+import { InlineCodeSnippet } from "~/components/common/InlineCodeSnippet";
+
+const baseIconCn = cn(
+  "w-10 h-10 flex items-center justify-center rounded-sm border"
+);
 
 export const getIcon = (role: OpenAI.ChatCompletionRole) => {
-  const baseCn = cn(
-    "w-10 h-10 flex items-center justify-center rounded-sm border"
-  );
-
   switch (role) {
     case "user":
       return (
-        <div className={cn(baseCn, "bg-purple-500")}>
+        <div className={cn(baseIconCn, "bg-purple-500")}>
           <UserIcon className="h-6 w-6 text-white" />
         </div>
       );
     case "assistant":
       return (
-        <div className={cn(baseCn, "bg-emerald-500")}>
+        <div className={cn(baseIconCn, "bg-emerald-500")}>
           <BotIcon className="h-6 w-6 text-white" />
         </div>
       );
     case "system":
       return (
-        <div className={cn(baseCn, "bg-stone-500")}>
+        <div className={cn(baseIconCn, "bg-stone-500")}>
           <WrenchIcon className="h-6 w-6 text-white" />
         </div>
       );
@@ -53,13 +60,63 @@ export const normalizeOpenAIChatResponse = (
 ): Chat => {
   const messages: ChatMessage[] = [];
 
+  console.log("request", request);
+
   // First, populate messages from the request
   request.messages.forEach((message) => {
-    messages.push({
-      icon: getIcon(message.role),
-      role: message.role,
-      content: message.content as string, // TODO: support vision model
-    });
+    if (Array.isArray(message.content)) {
+      const subMessages: SubChatMessage[] = [];
+      const contentParts = message.content;
+
+      contentParts.forEach((contentPart) => {
+        const { type } = contentPart;
+
+        if (type === "text") {
+          subMessages.push({
+            icon: (
+              <div className={cn(baseIconCn, "h-8 w-8", "bg-purple-500")}>
+                <TypeIcon className="h-5 w-5 text-white" />
+              </div>
+            ),
+            label: "text",
+            content: contentPart.text,
+          });
+        } else if (type === "image_url") {
+          subMessages.push({
+            icon: (
+              <div className={cn(baseIconCn, "h-8 w-8", "bg-purple-500")}>
+                <ImageIcon className="h-5 w-5 text-white" />
+              </div>
+            ),
+            label: "image",
+            content: (
+              <div className="space-y-2">
+                <div>
+                  <span className="font-semibold">Detail:</span>
+                  <InlineCodeSnippet>
+                    {contentPart.image_url.detail}
+                  </InlineCodeSnippet>
+                </div>
+                <img src={contentPart.image_url.url} alt="Report" />
+              </div>
+            ),
+          });
+        }
+      });
+
+      messages.push({
+        icon: getIcon(message.role),
+        role: message.role,
+        subMessages,
+        content: "",
+      });
+    } else {
+      messages.push({
+        icon: getIcon(message.role),
+        role: message.role,
+        content: message.content as string, // TODO: support vision model
+      });
+    }
   });
 
   // Then, populate response messages

--- a/apps/console/src/features/chat/types.ts
+++ b/apps/console/src/features/chat/types.ts
@@ -5,6 +5,13 @@ export type ChatMessage = {
   icon: string | React.ReactNode;
   role: OpenAI.ChatCompletionRole;
   content: string | React.ReactNode;
+  subMessages?: SubChatMessage[];
+};
+
+export type SubChatMessage = {
+  icon: string | React.ReactNode;
+  label: "text" | "image";
+  content: string | React.ReactNode;
 };
 
 export type Chat = {

--- a/apps/console/src/pages/requests/RequestTags.tsx
+++ b/apps/console/src/pages/requests/RequestTags.tsx
@@ -6,7 +6,7 @@ import {
   TooltipTrigger,
 } from "@pezzo/ui";
 import { RequestReportItem } from "./types";
-import { AlertTriangleIcon, FlaskConicalIcon, ZapIcon } from "lucide-react";
+import { AlertTriangleIcon, BugPlayIcon, ZapIcon } from "lucide-react";
 
 export const Tooltip = ({
   text,
@@ -49,7 +49,7 @@ export const RequestItemTags = ({
         <div
           className={cn(baseCn, "border-blue-900 bg-blue-950 text-blue-500")}
         >
-          <FlaskConicalIcon className="h-3 w-3" />
+          <BugPlayIcon className="h-3 w-3" />
           Test
         </div>
       </Tooltip>

--- a/apps/console/src/pages/requests/RequestsPage.tsx
+++ b/apps/console/src/pages/requests/RequestsPage.tsx
@@ -64,6 +64,13 @@ const getTableColumns = (): ColumnDef<RequestReportItem>[] => {
       enableSorting: true,
     },
     {
+      accessorKey: "model",
+      id: "model",
+      header: "Model",
+      cell: ({ row }) => <div className="font-mono">{row.original.model}</div>,
+      enableSorting: true,
+    },
+    {
       accessorKey: "duration",
       id: "duration",
       header: "Duration",
@@ -148,6 +155,7 @@ export const RequestsPage = () => {
           promptId: report.metadata?.promptId ?? null,
           cacheEnabled: report.cacheEnabled ?? false,
           cacheHit: report.cacheHit ?? false,
+          model: report.response.body.model as string,
         };
       }),
     [paginatedResults]

--- a/apps/console/src/pages/requests/types.ts
+++ b/apps/console/src/pages/requests/types.ts
@@ -11,4 +11,5 @@ export interface RequestReportItem {
   isTestPrompt: boolean;
   cacheEnabled: boolean;
   cacheHit: boolean;
+  model: string;
 }


### PR DESCRIPTION
Fixes #264 

Support rendering of images procued by the `gpt-4-1106-vision-preview` model.

<img width="684" alt="image" src="https://github.com/pezzolabs/pezzo/assets/4976416/1c7f72c3-eced-45d6-b814-d735ea325d05">
