### PR TITLE
fix(console): hidden tokens tooltip in request details

### DIFF
--- a/apps/console/src/components/prompts/prompt-tester/VariablesStep.tsx
+++ b/apps/console/src/components/prompts/prompt-tester/VariablesStep.tsx
@@ -21,7 +21,7 @@ export const VariablesStep = ({ onSubmit }: Props) => {
   };
 
   return (
-    <div>
+    <div className="p-6">
       <Form {...form}>
         <form onSubmit={form.handleSubmit(handleSubmit)}>
           <PromptVariables form={form} variables={testVariablesFormValues} />

--- a/apps/console/src/components/requests/RequestDetails.tsx
+++ b/apps/console/src/components/requests/RequestDetails.tsx
@@ -120,30 +120,33 @@ export const RequestDetails = (props: Props) => {
     },
     {
       title: "Tokens",
-      description: (
-        <div className="flex items-center gap-1">
-          <span>{props.calculated.totalTokens}</span>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                <CoinsIcon className="h-4 w-4 opacity-70" />
-              </TooltipTrigger>
-              <TooltipContent>
-                <div className="flex flex-col gap-2">
-                  <div className="flex justify-between gap-4">
-                    <span className="font-semibold">Completion tokens:</span>{" "}
-                    <span>{response.body.usage?.completion_tokens}</span>
+      description:
+        response.status !== 200 ? (
+          "0"
+        ) : (
+          <div className="flex items-center gap-1">
+            <span>{props.calculated.totalTokens}</span>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <CoinsIcon className="h-4 w-4 opacity-70" />
+                </TooltipTrigger>
+                <TooltipContent side="left">
+                  <div className="flex flex-col gap-2">
+                    <div className="flex justify-between gap-4">
+                      <span className="font-semibold">Completion tokens:</span>{" "}
+                      <span>{response.body.usage?.completion_tokens}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="font-semibold">Prompt tokens:</span>
+                      <span> {response.body.usage?.prompt_tokens}</span>
+                    </div>
                   </div>
-                  <div className="flex justify-between">
-                    <span className="font-semibold">Prompt tokens:</span>
-                    <span> {response.body.usage?.prompt_tokens}</span>
-                  </div>
-                </div>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-      ),
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        ),
     },
     {
       title: "Cost",


### PR DESCRIPTION
Fixes a bug where the details token usage is hidden behind a scrollbar when using the Prompt Tester.

<img width="185" alt="image" src="https://github.com/pezzolabs/pezzo/assets/4976416/bd0ebb73-2468-4c78-9cff-40704a822ddc">
