### PR TITLE
chore(env): add .env.example and related docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+## This file is an example of the .env and .env.docker files you should have before running docker-compose command
+
+PINO_PRETTIFY="true"
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/pezzo
+SUPERTOKENS_CONNECTION_URI="http://supertokens:3567"
+CONSOLE_HOST="http://pezzo-console:4200"
+KAFKA_BROKERS="kafka:9092"
+OPENSEARCH_URL="http://opensearch:9200"
+REDIS_URL="redis://redis-stack-server:6379"
+
+NX_BASE_API_URL="http://localhost:3000"
+NX_SUPERTOKENS_API_DOMAIN="http://localhost:3000"
+NX_SUPERTOKENS_WEBSITE_DOMAIN="http://localhost:4200"
+NX_DEBUG_MODE="true"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ Install NPM dependencies by running:
 npm install
 ```
 
+### Set up the environment files
+
+Pezzo uses a .env file to store environment variables.
+When using docker, you should also create a .env.docker file.
+
+See the .env.example file for reference.
+
 ### Spin up infrastructure dependencies via Docker Compose
 
 Pezzo is entirely cloud-native and relies solely on open-source technologies such as [PostgreSQL](https://www.postgresql.org/), [ClickHouse](https://github.com/ClickHouse/ClickHouse), [Redis](https://github.com/redis/redis) and [Supertokens](https://supertokens.com/).


### PR DESCRIPTION
Fixes https://github.com/pezzolabs/pezzo/issues/302

Many has been complaining about not being able to just follow the readme file to run Pezzo.
This PR suggest the required changes in order to make it a little bit more clear on how to run the project.
In features a `.env.example` file that can be just copied over, and a small explanation on the readme.

Possibly lacking: Changes to the official mintlify documentation