### PR TITLE
feat(proxy): enable pre configured openai base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ NX_BASE_API_URL="http://localhost:3000"
 NX_SUPERTOKENS_API_DOMAIN="http://localhost:3000"
 NX_SUPERTOKENS_WEBSITE_DOMAIN="http://localhost:4200"
 NX_DEBUG_MODE="true"
+
+# Pezzo config
+OPENAI_API_BASE_URL="https://api.openai.com/v1"

--- a/apps/proxy/src/lib/OpenAIHandler.ts
+++ b/apps/proxy/src/lib/OpenAIHandler.ts
@@ -3,6 +3,8 @@ import { RequestWithPezzoClient } from "../types/common.types";
 import { Response } from "express";
 import axios from "axios";
 
+const baseUrl = process.env.OPENAI_API_BASE_URL ?? "https://api.openai.com/v1";
+
 export class OpenAIV1Handler {
   constructor(private req: RequestWithPezzoClient, private res: Response) {}
 
@@ -16,7 +18,7 @@ export class OpenAIV1Handler {
       try {
         const result = await axios({
           method,
-          url: `https://api.openai.com/v1/${url}`,
+          url: `${baseUrl}/${url}`,
           data: this.req.body,
           headers: {
             Authorization: headers.authorization,


### PR DESCRIPTION
Fixes 2nd point on https://github.com/pezzolabs/pezzo/issues/295.
With a simple env var, you should now be able to configure the base URL of openai. If for some reason (as mentioned in the issue) you have your own "copy" of the API.

Please bear in mind that pezzo assumes an exact API structure other than the base URL.
So for an `api.openai.com/some/url`, if you choose to replace base url, you should have `/some/url` also in your "own implementation" of the API.