### PR TITLE
Correct typos in various documentation and script files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We opened sourced Pezzo because we believe in the power of community. We believe you can help making Pezzo better!
+We open sourced Pezzo because we believe in the power of community. We believe you can help making Pezzo better!
 We are excited to see what you will build with Pezzo and we are looking forward to your contributions. We want to make contributing to this project as easy and transparent as possible, whether it's features, bug fixes, documentation updates, guides, examples and more.
 
 ## How can I contribute?

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Looking for a client that's not listed here? [Open an issue](https://github.com/
 
 # Getting Started - Docker Compose
 
-If you simplay want to run the full Pezzo stack locally, check out [Running With Docker Compose](http://docs.pezzo.ai/introduction/docker-compose) in the documentation.
+If you simply want to run the full Pezzo stack locally, check out [Running With Docker Compose](http://docs.pezzo.ai/introduction/docker-compose) in the documentation.
 
 If you want to run Pezzo in development mode, continue reading.
 

--- a/libs/client/README.md
+++ b/libs/client/README.md
@@ -44,4 +44,4 @@ The Pezzo Documentation contains useful information on how to use the Pezzo clie
 
 ## License
 
-The `@pezzo/client` library is provided under the Apache 2.0 licesnse.
+The `@pezzo/client` library is provided under the Apache 2.0 license.

--- a/libs/common/scripts/sync-version.ts
+++ b/libs/common/scripts/sync-version.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 
-console.log("Syncing version");
+console.log("Synchronizing version");
 const packageJsonFile = fs.readFileSync("./package.json", "utf8");
 const packageJson = JSON.parse(packageJsonFile);
 const version = packageJson.version;


### PR DESCRIPTION
* **CONTRIBUTING.md**
  - Correct "We opened sourced Pezzo" to "We open sourced Pezzo"
* **libs/client/README.md**
  - Correct "licesnse" to "license"
* **README.md**
  - Correct "simplay" to "simply"
* **libs/common/scripts/sync-version.ts**
  - Correct "Syncing version" to "Synchronizing version"