### PR TITLE
Security: SQL injection risk via string-interpolated `projectId` in raw SQL join

### DIFF
--- a/apps/proxy/src/lib/middleware/create-openai-client-from-request.ts
+++ b/apps/proxy/src/lib/middleware/create-openai-client-from-request.ts
@@ -15,6 +15,10 @@ export function createPezzoClientFromRequest(
     return res.status(400).send("Missing x-pezzo-project-id header");
   }
 
+  if (Array.isArray(req.headers["x-pezzo-project-id"])) {
+    return res.status(400).send("Invalid x-pezzo-project-id header");
+  }
+
   if (!req.headers["x-pezzo-environment"]) {
     return res.status(400).send("Missing x-pezzo-environment header");
   }

--- a/apps/server/src/app/metrics/queries/average-request-duration-query.ts
+++ b/apps/server/src/app/metrics/queries/average-request-duration-query.ts
@@ -33,7 +33,8 @@ export const averageRequestDurationQuery = (
     .leftJoin("reports as r", (join) =>
       join.on(
         knex.raw(
-          `${timeProps.roundFn}(r.requestTimestamp) = b.timestamp AND r."projectId" = '${projectId}'`
+          `${timeProps.roundFn}(r.requestTimestamp) = b.timestamp AND r."projectId" = ?`,
+          [projectId]
         )
       )
     )


### PR DESCRIPTION
## Problem

The query builder composes a raw SQL predicate using direct string interpolation of `projectId` inside `knex.raw(...)` (`... r."projectId" = '${projectId}'`). If an attacker can influence `projectId`, this can alter SQL logic and potentially expose or corrupt data.

**Severity**: `high`
**File**: `apps/server/src/app/metrics/queries/average-request-duration-query.ts`

## Solution

Use parameter binding instead of interpolation, e.g. `knex.raw(`${timeProps.roundFn}(r.requestTimestamp) = b.timestamp AND r."projectId" = ?`, [projectId])`, or build the condition with knex join methods (`join.on`, `join.andOn`) to avoid raw string concatenation.

## Changes

- `apps/server/src/app/metrics/queries/average-request-duration-query.ts` (modified)
- `apps/proxy/src/lib/middleware/create-openai-client-from-request.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
