### PR TITLE
Security: Server-side request forgery (SSRF) primitive via untrusted `x-pezzo-server-url` header

### DIFF
--- a/apps/proxy/src/lib/middleware/create-openai-client-from-request.ts
+++ b/apps/proxy/src/lib/middleware/create-openai-client-from-request.ts
@@ -23,16 +23,12 @@ export function createPezzoClientFromRequest(
     apiKey: string;
     projectId: string;
     environment: string;
-    serverUrl?: string;
   } = {
     apiKey: req.headers["x-pezzo-api-key"] as string,
     projectId: req.headers["x-pezzo-project-id"] as string,
     environment: req.headers["x-pezzo-environment"] as string,
   };
 
-  if (req.headers["x-pezzo-server-url"]) {
-    options.serverUrl = req.headers["x-pezzo-server-url"] as string;
-  }
 
   req.pezzo = new Pezzo(options);
   next();


### PR DESCRIPTION
## Problem

The proxy trusts `x-pezzo-server-url` from incoming requests and forwards it into Pezzo client configuration (`options.serverUrl`). This lets a client choose arbitrary backend destinations, which can be abused to reach internal services or metadata endpoints.

**Severity**: `high`
**File**: `apps/proxy/src/lib/middleware/create-openai-client-from-request.ts`

## Solution

Do not accept backend target URLs from client headers. Enforce a fixed server URL from configuration, or strictly allowlist approved hosts/schemes and reject private/internal IP ranges.

## Changes

- `apps/proxy/src/lib/middleware/create-openai-client-from-request.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
