### PR TITLE
fix(server): resolve ClickHouse syntax error in getProjectMetricDelta…

### DIFF
--- a/apps/server/src/app/metrics/project-metrics.service.ts
+++ b/apps/server/src/app/metrics/project-metrics.service.ts
@@ -105,7 +105,7 @@ export class ProjectMetricsService {
       WITH (
         parseDateTimeBestEffort('${startDate.toISOString()}') AS currentStartDate,
         parseDateTimeBestEffort('${endDate.toISOString()}') AS currentEndDate,
-        datediff(second, currentStartDate, currentEndDate) AS diff,
+        datediff('second', currentStartDate, currentEndDate) AS diff,
         subtractSeconds(currentStartDate, diff) AS previousStartDate,
         subtractSeconds(currentEndDate, diff) AS previousEndDate
       )


### PR DESCRIPTION
Closes #319

### Description
Entering the project dashboard crashes the UI with a `Failed to get metric delta` error. This was caused by a syntax error in the ClickHouse `datediff` function inside `getProjectMetricDelta` where the unit parameter `second` was specified as an identifier instead of a string literal.

### Changes
- Wrapped `second` in single quotes to make it `'second'` in the ClickHouse query within `apps/server/src/app/metrics/project-metrics.service.ts`.
- Verified the query compiles, the database migrations run, and the metrics endpoint returns values without syntax errors.
