### PR TITLE
fix: Running locally; always getting "Invalid Pezzo Project ID"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,6 +64,8 @@ services:
     env_file:
       - ./.env
       - ./apps/proxy/.env
+    environment:
+      - PEZZO_SERVER_URL=http://pezzo-server:3000
     ports:
       - "3001:3000"
     depends_on:


### PR DESCRIPTION
Fixes #299

## Root cause

Docker Compose proxy has no PEZZO_SERVER_URL, so it reports to Pezzo Cloud

## Changes

- Set PEZZO_SERVER_URL=http://pezzo-server:3000 for the pezzo-proxy service in docker-compose.yaml so the proxy's Pezzo client reports executions to the local server instead of falling back to the https://api.pezzo.ai default.