### PR TITLE
fix: docker-compose fails to start the service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 
 PINO_PRETTIFY="true"
 DATABASE_URL=postgresql://postgres:postgres@postgres:5432/pezzo
+SUPERTOKENS_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/pezzo
 SUPERTOKENS_CONNECTION_URI="http://supertokens:3567"
 CONSOLE_HOST="http://pezzo-console:4200"
 KAFKA_BROKERS="kafka:9092"

--- a/docker-compose.infra.yaml
+++ b/docker-compose.infra.yaml
@@ -55,6 +55,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: pezzo
     ports:
       - "5433:5432"
     volumes:
@@ -75,7 +76,7 @@ services:
     env_file:
       - ./.env.docker
     environment:
-      POSTGRES_CONNECTION_URI: "${SUPERTOKENS_DATABASE_URL}"
+      POSTGRES_CONNECTION_URI: "${SUPERTOKENS_DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/pezzo}"
     healthcheck:
       test: >
         bash -c 'exec 3<>/dev/tcp/127.0.0.1/3567 && echo -e "GET /hello HTTP/1.1\r\nhost: 127.0.0.1:3567\r\nConnection: close\r\n\r\n" >&3 && cat <&3 | grep "Hello"'


### PR DESCRIPTION
Fixes #309

## Root cause

Infra compose lacks the `pezzo` database and a usable Supertokens connection URI

## Changes

- Create the `pezzo` database in the Postgres service via POSTGRES_DB, give POSTGRES_CONNECTION_URI a working local default when SUPERTOKENS_DATABASE_URL is unset, and document SUPERTOKENS_DATABASE_URL in .env.example.