### PR TITLE
fix: ClickHouseError: CANNOT_PARSE_INPUT_ASSERTION_FAILED

### DIFF
--- a/apps/server/src/app/reporting/reporting.service.ts
+++ b/apps/server/src/app/reporting/reporting.service.ts
@@ -74,6 +74,9 @@ export class ReportingService {
         format: "JSONEachRow",
         table: "reports",
         values: [reportToSave],
+        clickhouse_settings: {
+          date_time_input_format: "best_effort",
+        },
       });
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
Fixes #320

## Root cause

ISO-8601 timestamps inserted into ClickHouse DateTime columns with date_time_input_format=basic

## Changes

- Send the reports insert with clickhouse_settings.date_time_input_format = 'best_effort' so ClickHouse parses the ISO-8601 timestamp/requestTimestamp/responseTimestamp values regardless of server default.